### PR TITLE
Feature/44-comment-api-back

### DIFF
--- a/backend/src/api/auth/auth.controller.ts
+++ b/backend/src/api/auth/auth.controller.ts
@@ -38,8 +38,8 @@ export class AuthController {
 	 * @summary Local User 로그인
 	 *
 	 * @tag auth
-	 * @param email string
-	 * @param password string
+	 * @param {string} dto.email - 로그인을 위한 email
+	 * @param {string} dto.password - 로그인을 위한 pw
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns 토큰
 	 */
@@ -66,7 +66,10 @@ export class AuthController {
 	 * @summary Local 로그인을 위한 User 생성
 	 *
 	 * @tag auth
-	 * @param MemberCreateReqDto 유저를 생성하기 위해 필요한 최소한의 값 정의
+	 * @param {string} dto.email - email
+	 * @param {string} dto.username - 유저 이름
+	 * @param {string} dto.password - 비밀번호
+	 * @param {string} dto.phoneNumber - 휴대폰번호
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns 유저이름
 	 */
@@ -80,7 +83,8 @@ export class AuthController {
 	 * @summary Local User 생성 확인을 위한 email 검즘
 	 *
 	 * @tag auth
-	 * @param VerifyEmailReqDto 이메일 검증 하기 위해 필요한 최소한의 값 정의
+	 * @param {string} dto.email 이메일 검증 하기 위해 필요한 email
+	 * @param {string} dto.signupVerifyToken 이메일 검증 코드
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns 유저이름
 	 */
@@ -94,6 +98,7 @@ export class AuthController {
 	 * @summary Local User 로그아웃
 	 *
 	 * @tag auth
+	 * @param {string} sub - 인증된 유저Id
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns 쿠키삭제, refreshtoken 값 초기화
 	 */
@@ -110,6 +115,9 @@ export class AuthController {
 	 * @summary Local User refreshtoken 재발급 및 accesstoken 재발급
 	 *
 	 * @tag auth
+	 * @param {string} user.username - 인증된 사용자의 username
+	 * @param {string} user.sub - 인증된 사용자의 Id
+	 * @param {string} user.refreshToken - 인증된 사용자의 refreshToken
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns 토큰
 	 */

--- a/backend/src/api/comments/comments.controller.ts
+++ b/backend/src/api/comments/comments.controller.ts
@@ -1,0 +1,14 @@
+import { AccessTokenGuard } from '@/common/guards/accessToken.guard';
+import { LoggingInterceptor } from '@/common/interceptors/logging.interceptor';
+import { TimeoutInterceptor } from '@/common/interceptors/timeout.interceptor';
+import { Controller, UseGuards, UseInterceptors } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { CommentsService } from './comments.service';
+
+@UseInterceptors(LoggingInterceptor, TimeoutInterceptor)
+@UseGuards(AccessTokenGuard)
+@ApiTags('comments')
+@Controller('comments')
+export class CommentsController {
+	constructor(private readonly commentsService: CommentsService) {}
+}

--- a/backend/src/api/comments/comments.controller.ts
+++ b/backend/src/api/comments/comments.controller.ts
@@ -20,31 +20,4 @@ import { CreateCommentSwagger } from '@/common/decorators/swagger/swagger-commen
 @Controller('comments')
 export class CommentsController {
 	constructor(private readonly commentsService: CommentsService) {}
-
-	/**
-	 * @summary 특정 feed에 댓글, 대댓글, 대대댓글 작성
-	 *
-	 * @tag comments
-	 * @param {string} dto.commentContents - 댓글의 글내용
-	 * @param {string} dto.replyId  - 실제 답글 단 댓글의 Id
-	 * @param {string} dto.parentId - 최초 부모격인 댓글 Id
-	 * @param {string} dto.feedId   - 특정 feed의 Id
-	 * @param {string} sub  	    - 멤버Id
-	 * @author YangGwangSeong <soaw83@gmail.com>
-	 * @returns 피드id, 피드 공개/비공개
-	 */
-	@CreateCommentSwagger()
-	@Post()
-	async createComments(
-		@CurrentUser('sub') sub: string,
-		@Body() dto: CommentCreateReqDto,
-	) {
-		return await this.commentsService.createComments({
-			commentContents: dto.commentContents,
-			replyId: dto.replyId,
-			parentId: dto.parentId,
-			feedId: dto.feedId,
-			memberId: sub,
-		});
-	}
 }

--- a/backend/src/api/comments/comments.controller.ts
+++ b/backend/src/api/comments/comments.controller.ts
@@ -1,9 +1,18 @@
 import { AccessTokenGuard } from '@/common/guards/accessToken.guard';
 import { LoggingInterceptor } from '@/common/interceptors/logging.interceptor';
 import { TimeoutInterceptor } from '@/common/interceptors/timeout.interceptor';
-import { Controller, UseGuards, UseInterceptors } from '@nestjs/common';
+import {
+	Body,
+	Controller,
+	Post,
+	UseGuards,
+	UseInterceptors,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { CommentsService } from './comments.service';
+import { CurrentUser } from '@/common/decorators/user.decorator';
+import { CommentCreateReqDto } from '@/models/dto/comments/req/comment-create-req.dto';
+import { CreateCommentSwagger } from '@/common/decorators/swagger/swagger-comment.decorator';
 
 @UseInterceptors(LoggingInterceptor, TimeoutInterceptor)
 @UseGuards(AccessTokenGuard)
@@ -11,4 +20,31 @@ import { CommentsService } from './comments.service';
 @Controller('comments')
 export class CommentsController {
 	constructor(private readonly commentsService: CommentsService) {}
+
+	/**
+	 * @summary 특정 feed에 댓글, 대댓글, 대대댓글 작성
+	 *
+	 * @tag comments
+	 * @param {string} dto.commentContents - 댓글의 글내용
+	 * @param {string} dto.replyId  - 실제 답글 단 댓글의 Id
+	 * @param {string} dto.parentId - 최초 부모격인 댓글 Id
+	 * @param {string} dto.feedId   - 특정 feed의 Id
+	 * @param {string} sub  	    - 멤버Id
+	 * @author YangGwangSeong <soaw83@gmail.com>
+	 * @returns 피드id, 피드 공개/비공개
+	 */
+	@CreateCommentSwagger()
+	@Post()
+	async createComments(
+		@CurrentUser('sub') sub: string,
+		@Body() dto: CommentCreateReqDto,
+	) {
+		return await this.commentsService.createComments({
+			commentContents: dto.commentContents,
+			replyId: dto.replyId,
+			parentId: dto.parentId,
+			feedId: dto.feedId,
+			memberId: sub,
+		});
+	}
 }

--- a/backend/src/api/comments/comments.module.ts
+++ b/backend/src/api/comments/comments.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CommentsRepository } from '@/models/repositories/comments.repository';
+import { LikesCommentRepository } from '@/models/repositories/likes-comment.repository';
+import { CommentEntity } from '@/models/entities/comment.entity';
+import { LikeCommentEntity } from '@/models/entities/fam-like-comment.entity';
+import { CommentsService } from './comments.service';
+import { CommentsController } from './comments.controller';
+
+@Module({
+	imports: [TypeOrmModule.forFeature([CommentEntity, LikeCommentEntity])],
+	controllers: [CommentsController],
+	providers: [CommentsService, CommentsRepository, LikesCommentRepository],
+	exports: [],
+})
+export class CommentsModule {}

--- a/backend/src/api/comments/comments.module.ts
+++ b/backend/src/api/comments/comments.module.ts
@@ -11,6 +11,6 @@ import { CommentsController } from './comments.controller';
 	imports: [TypeOrmModule.forFeature([CommentEntity, LikeCommentEntity])],
 	controllers: [CommentsController],
 	providers: [CommentsService, CommentsRepository, LikesCommentRepository],
-	exports: [],
+	exports: [CommentsService],
 })
 export class CommentsModule {}

--- a/backend/src/api/comments/comments.service.ts
+++ b/backend/src/api/comments/comments.service.ts
@@ -1,0 +1,13 @@
+import { CommentsRepository } from '@/models/repositories/comments.repository';
+import { LikesCommentRepository } from '@/models/repositories/likes-comment.repository';
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class CommentsService {
+	constructor(
+		private readonly commentsRepository: CommentsRepository,
+		private readonly likesCommentRepository: LikesCommentRepository,
+		private dataSource: DataSource,
+	) {}
+}

--- a/backend/src/api/comments/comments.service.ts
+++ b/backend/src/api/comments/comments.service.ts
@@ -20,6 +20,10 @@ export class CommentsService {
 		private dataSource: DataSource,
 	) {}
 
+	async getCommentsByFeedId(feedId: string) {
+		return await this.commentsRepository.getCommentsByFeedId(feedId);
+	}
+
 	async createComment({
 		commentContents,
 		replyId,

--- a/backend/src/api/comments/comments.service.ts
+++ b/backend/src/api/comments/comments.service.ts
@@ -1,5 +1,6 @@
 import { CommentsRepository } from '@/models/repositories/comments.repository';
 import { LikesCommentRepository } from '@/models/repositories/likes-comment.repository';
+import { ICreateCommentsArgs } from '@/types/args/comment';
 import { Injectable } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 
@@ -10,4 +11,20 @@ export class CommentsService {
 		private readonly likesCommentRepository: LikesCommentRepository,
 		private dataSource: DataSource,
 	) {}
+
+	async createComments({
+		commentContents,
+		replyId,
+		parentId,
+		feedId,
+		memberId,
+	}: ICreateCommentsArgs) {
+		return await this.commentsRepository.createComments({
+			commentContents,
+			replyId,
+			parentId,
+			feedId,
+			memberId,
+		});
+	}
 }

--- a/backend/src/api/comments/comments.service.ts
+++ b/backend/src/api/comments/comments.service.ts
@@ -1,3 +1,5 @@
+import { EntityNotFoundException } from '@/common/exception/service.exception';
+import { ERROR_COMMENT_NOT_FOUND } from '@/constants/business-error';
 import { CommentsRepository } from '@/models/repositories/comments.repository';
 import { LikesCommentRepository } from '@/models/repositories/likes-comment.repository';
 import { ICreateCommentsArgs } from '@/types/args/comment';
@@ -12,19 +14,38 @@ export class CommentsService {
 		private dataSource: DataSource,
 	) {}
 
-	async createComments({
+	async createComment({
 		commentContents,
 		replyId,
 		parentId,
 		feedId,
 		memberId,
 	}: ICreateCommentsArgs) {
-		return await this.commentsRepository.createComments({
+		return await this.commentsRepository.createComment({
 			commentContents,
 			replyId,
 			parentId,
 			feedId,
 			memberId,
 		});
+	}
+
+	async updateComment(commentId: string, commentContents: string) {
+		return await this.commentsRepository.updateComment(
+			commentId,
+			commentContents,
+		);
+	}
+
+	async findCommentByIdOrThrow(commentId: string) {
+		const comment = this.commentsRepository.findOneBy({
+			id: commentId,
+		});
+
+		if (!comment) {
+			throw EntityNotFoundException(ERROR_COMMENT_NOT_FOUND);
+		}
+
+		return comment;
 	}
 }

--- a/backend/src/api/comments/comments.service.ts
+++ b/backend/src/api/comments/comments.service.ts
@@ -1,5 +1,11 @@
-import { EntityNotFoundException } from '@/common/exception/service.exception';
-import { ERROR_COMMENT_NOT_FOUND } from '@/constants/business-error';
+import {
+	EntityConflictException,
+	EntityNotFoundException,
+} from '@/common/exception/service.exception';
+import {
+	ERROR_COMMENT_NOT_FOUND,
+	ERROR_DELETE_COMMENT,
+} from '@/constants/business-error';
 import { CommentsRepository } from '@/models/repositories/comments.repository';
 import { LikesCommentRepository } from '@/models/repositories/likes-comment.repository';
 import { ICreateCommentsArgs } from '@/types/args/comment';
@@ -37,11 +43,17 @@ export class CommentsService {
 		);
 	}
 
+	async deleteComment(commentId: string) {
+		const deleteStatus = await this.commentsRepository.deleteComment(commentId);
+
+		if (!deleteStatus) throw EntityConflictException(ERROR_DELETE_COMMENT);
+	}
+
 	async findCommentByIdOrThrow(commentId: string) {
-		const comment = this.commentsRepository.findOneBy({
+		const comment = await this.commentsRepository.findOneBy({
 			id: commentId,
 		});
-
+		console.log('comment', comment);
 		if (!comment) {
 			throw EntityNotFoundException(ERROR_COMMENT_NOT_FOUND);
 		}

--- a/backend/src/api/fams/fams.controller.ts
+++ b/backend/src/api/fams/fams.controller.ts
@@ -18,7 +18,7 @@ export class FamsController {
 	 * @summary 수락하지 않은 팸 초대 리스트를 조회
 	 *
 	 * @tag fams
-	 * @param sub 인증된 유저 아이디
+	 * @param {string} sub - 인증된 유저 아이디
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns 팸 초대 리스트, 총 갯수
 	 */

--- a/backend/src/api/feeds/feeds.controller.ts
+++ b/backend/src/api/feeds/feeds.controller.ts
@@ -46,7 +46,7 @@ export class FeedsController {
 	 * @summary 단일 피드를 가져옵니다
 	 *
 	 * @tag feeds
-	 * @param feedId 단일 피드를 조회하기 위한 피드 아이디
+	 * @param {string} feedId - 단일 피드를 조회하기 위한 피드 아이디
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns feed
 	 */
@@ -60,8 +60,8 @@ export class FeedsController {
 	 * @summary 피드를 가져옵니다.
 	 *
 	 * @tag feeds
-	 * @param page 페이징을 위한 page 번호
-	 * @param sub  	   멤버Id
+	 * @param {number} page - 페이징을 위한 page 번호
+	 * @param {string} sub  - 인증된 사용자의 아이디
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns feed
 	 */
@@ -79,10 +79,11 @@ export class FeedsController {
 	 * @summary 유저가 속하는 Group에서 feed 생성
 	 *
 	 * @tag feeds
-	 * @param contents 피드 글내용
-	 * @param isPublic 피드 공개/비공개
-	 * @param groupId  유저가 속하는 그룹 Id
-	 * @param sub  	   멤버Id
+	 * @param {string} 	dto.contents - 피드 글내용
+	 * @param {boolean} dto.isPublic - 피드 공개/비공개
+	 * @param {string} 	dto.groupId  - 유저가 속하는 그룹 Id
+	 * @param {MediaCreateReqDto[]} dto.medias - 미디어 파일들
+	 * @param {string}  sub  	   	 - 멤버Id
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns 피드id, 피드 공개/비공개
 	 */
@@ -111,10 +112,11 @@ export class FeedsController {
 	 * @summary feed 수정
 	 *
 	 * @tag feeds
-	 * @param contents 피드 글내용
-	 * @param isPublic 피드 공개/비공개
-	 * @param groupId  유저가 속하는 그룹 Id
-	 * @param feedId   피드Id
+	 * @param {string} dto.contents - 피드 글내용
+	 * @param {boolean} dto.isPublic - 피드 공개/비공개
+	 * @param {string} dto.groupId  - 유저가 속하는 그룹 Id
+	 * @param {string} feedId   	- 피드Id
+	 * @param {MediaCreateReqDto[]} dto.medias - 미디어 파일들
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns void
 	 */
@@ -137,8 +139,8 @@ export class FeedsController {
 	 * @summary feed 좋아요
 	 *
 	 * @tag feeds
-	 * @param sub  멤버 Id
-	 * @param feedId   피드Id
+	 * @param {string} sub  	- 멤버 Id
+	 * @param {string} feedId  	- 피드Id
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns boolean
 	 */
@@ -155,7 +157,7 @@ export class FeedsController {
 	 * @summary feed 삭제
 	 *
 	 * @tag feeds
-	 * @param feedId   피드Id
+	 * @param {string} feedId  - 피드Id
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns void
 	 */

--- a/backend/src/api/feeds/feeds.controller.ts
+++ b/backend/src/api/feeds/feeds.controller.ts
@@ -36,6 +36,7 @@ import {
 import { FeedUpdateReqDto } from '@/models/dto/feed/req/feed-update.req.dto';
 import {
 	CreateCommentSwagger,
+	DeleteCommentSwagger,
 	UpdateCommentSwagger,
 } from '@/common/decorators/swagger/swagger-comment.decorator';
 import { CommentCreateReqDto } from '@/models/dto/comments/req/comment-create-req.dto';
@@ -234,8 +235,7 @@ export class FeedsController {
 	@UpdateCommentSwagger()
 	@Put(':feedId/comments/:commentId')
 	async updateComment(
-		@Body()
-		dto: CommentUpdateReqDto,
+		@Body() dto: CommentUpdateReqDto,
 		@Param('feedId', ParseUUIDPipe) feedId: string,
 		@Param('commentId', ParseUUIDPipe) commentId: string,
 	) {
@@ -248,5 +248,28 @@ export class FeedsController {
 			commentId,
 			dto.commentContents,
 		);
+	}
+
+	/**
+	 * @summary 특정 댓글 삭제하기
+	 *
+	 * @tag comments
+	 * @param {string} feedId   			- 특정 feed의 Id
+	 * @param {string} commentId  	    	- 수정 할 댓글 아이디
+	 * @author YangGwangSeong <soaw83@gmail.com>
+	 * @returns void
+	 */
+	@DeleteCommentSwagger()
+	@Delete(':feedId/comments/:commentId')
+	async deleteComment(
+		@Param('feedId', ParseUUIDPipe) feedId: string,
+		@Param('commentId', ParseUUIDPipe) commentId: string,
+	) {
+		// 피드가 존재 하는지 check;
+		await this.feedsService.findFeedByIdOrThrow(feedId);
+		// 댓글이 존재 하는지 check;
+		await this.commentsService.findCommentByIdOrThrow(commentId);
+
+		return await this.commentsService.deleteComment(commentId);
 	}
 }

--- a/backend/src/api/feeds/feeds.module.ts
+++ b/backend/src/api/feeds/feeds.module.ts
@@ -7,11 +7,13 @@ import { FeedEntity } from '@/models/entities/feed.entity';
 import { MediasModule } from '../medias/medias.module';
 import { LikeFeedEntity } from '@/models/entities/fam-like-feed.entity';
 import { LikesFeedRepository } from '@/models/repositories/likes-feed.repository';
+import { CommentsModule } from '../comments/comments.module';
 
 @Module({
 	imports: [
 		TypeOrmModule.forFeature([FeedEntity, LikeFeedEntity]),
 		MediasModule,
+		CommentsModule,
 	],
 	controllers: [FeedsController],
 	providers: [FeedsService, FeedsRepository, LikesFeedRepository],

--- a/backend/src/api/feeds/feeds.service.ts
+++ b/backend/src/api/feeds/feeds.service.ts
@@ -21,12 +21,14 @@ import { getOffset } from '@/utils/getOffset';
 import { FeedResDto } from '@/models/dto/feed/res/feed-res.dto';
 import { LikesFeedRepository } from '@/models/repositories/likes-feed.repository';
 import { FeedGetAllResDto } from '@/models/dto/feed/res/feed-get-all-res.dto';
+import { CommentsService } from '../comments/comments.service';
 
 @Injectable()
 export class FeedsService {
 	constructor(
 		private readonly feedsRepository: FeedsRepository,
 		private readonly mediasService: MediasService,
+		private readonly commentsService: CommentsService,
 		private readonly likesFeedRepository: LikesFeedRepository,
 		private dataSource: DataSource,
 	) {}
@@ -63,16 +65,16 @@ export class FeedsService {
 			memberId,
 		});
 
-		//[TODO comments 추후에 추가]
 		const mappedList = await Promise.all(
 			list.map(async (feed) => {
-				const medias = await this.mediasService.findMediaUrlByFeedId(
+				const [medias, comments] = await this.getMediaUrlAndCommentsByFeedId(
 					feed.feedId,
 				);
 
 				return {
 					...feed,
 					medias: medias,
+					comments: comments,
 				};
 			}),
 		);
@@ -190,5 +192,12 @@ export class FeedsService {
 		}
 
 		return feed;
+	}
+
+	private async getMediaUrlAndCommentsByFeedId(feedId: string) {
+		return await Promise.all([
+			await this.mediasService.findMediaUrlByFeedId(feedId),
+			await this.commentsService.getCommentsByFeedId(feedId),
+		]);
 	}
 }

--- a/backend/src/api/groups/groups.controller.ts
+++ b/backend/src/api/groups/groups.controller.ts
@@ -55,7 +55,7 @@ export class GroupsController {
 	 * @summary 유저가 속한 모든 그룹 가져오기
 	 *
 	 * @tag groups
-	 * @param sub 인증된 유저 아이디
+	 * @param {string} sub - 인증된 유저 아이디
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns 그룹명
 	 */
@@ -71,9 +71,9 @@ export class GroupsController {
 	 * @summary 유저가 속하는 Group생성
 	 *
 	 * @tag groups
-	 * @param groupName 그룹 이름
-	 * @param groupDescription 그룹 설명
-	 * @param sub 인증된 유저 아이디
+	 * @param {string} dto.groupName - 그룹 이름
+	 * @param {string} dto.groupDescription - 그룹 설명
+	 * @param {string} sub - 인증된 유저 아이디
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns 그룹명
 	 */
@@ -94,9 +94,10 @@ export class GroupsController {
 	 * @summary 그룹 정보 수정
 	 *
 	 * @tag groups
-	 * @param groupName 그룹 이름
-	 * @param groupDescription 그룹 설명
-	 * @param sub 인증된 유저 아이디
+	 * @param {string} dto.groupName - 그룹 이름
+	 * @param {string} dto.groupDescription - 그룹 설명
+	 * @param {string} groupId - 수정 할 그룹 아이디
+	 * @param {string} sub - 인증된 유저 아이디
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns 그룹명
 	 */
@@ -119,8 +120,8 @@ export class GroupsController {
 	 * @summary 그룹 삭제
 	 *
 	 * @tag groups
-	 * @param groupId string
-	 * @param sub 인증된 유저 아이디
+	 * @param {string} groupId - 삭제 할 그룹 아이디
+	 * @param {string} sub - 인증된 유저 아이디
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns void
 	 */
@@ -140,9 +141,9 @@ export class GroupsController {
 	 * @summary 특정 그룹의 특정 멤버의 fam 생성
 	 *
 	 * @tag groups
-	 * @param sub 인증된 유저 아이디
-	 * @param memberId 초대받은 특정 멤버의 아이디
-	 * @param groupId 초대받은 그룹 아이디
+	 * @param {string} sub - 인증된 유저 아이디
+	 * @param {string} memberId - 초대받은 특정 멤버의 아이디
+	 * @param {string} groupId - 초대받은 그룹 아이디
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns void
 	 */
@@ -172,11 +173,11 @@ export class GroupsController {
 	 * @summary 그룹 초대 수락하기
 	 *
 	 * @tag groups
-	 * @param sub 인증된 유저 아이디
-	 * @param groupId 초대받은 그룹 아이디
-	 * @param memberId 초대받은 멤버 아이디
-	 * @param famId 대상이 되는 fam 테이블의 레코드 아이디
-	 * @param invitationAccepted 초대 수락 여/부
+	 * @param {string} sub - 인증된 유저 아이디
+	 * @param {string} groupId - 초대받은 그룹 아이디
+	 * @param {string} memberId - 초대받은 멤버 아이디
+	 * @param {string} famId - 대상이 되는 fam 테이블의 레코드 아이디
+	 * @param {boolean} dto.invitationAccepted - 초대 수락 여/부
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns void
 	 */
@@ -213,9 +214,9 @@ export class GroupsController {
 	 * @summary 특정 그룹의 특정 멤버의 fam 삭제
 	 *
 	 * @tag groups
-	 * @param groupId 그룹 아이디
-	 * @param memberId  대상이 되는 멤버 아이디
-	 * @param famId  대상이 되는 fam 테이블의 레코드 아이디
+	 * @param {string} groupId 		- 그룹 아이디
+	 * @param {string} memberId  	- 대상이 되는 멤버 아이디
+	 * @param {string} famId  		- 대상이 되는 fam 테이블의 레코드 아이디
 	 * @author YangGwangSeong <soaw83@gmail.com>
 	 * @returns void
 	 */

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { GroupsModule } from './api/groups/groups.module';
 import { FamsModule } from './api/fams/fams.module';
 import { FeedsModule } from './api/feeds/feeds.module';
 import { MediasModule } from './api/medias/medias.module';
+import { CommentsModule } from './api/comments/comments.module';
 
 @Module({
 	imports: [
@@ -28,6 +29,7 @@ import { MediasModule } from './api/medias/medias.module';
 		FamsModule,
 		FeedsModule,
 		MediasModule,
+		CommentsModule,
 	],
 	controllers: [],
 	providers: [],

--- a/backend/src/common/decorators/swagger/swagger-comment.decorator.ts
+++ b/backend/src/common/decorators/swagger/swagger-comment.decorator.ts
@@ -1,5 +1,13 @@
+import {
+	ERROR_COMMENT_NOT_FOUND,
+	ERROR_FEED_NOT_FOUND,
+} from '@/constants/business-error';
 import { applyDecorators } from '@nestjs/common';
-import { ApiCreatedResponse, ApiOperation } from '@nestjs/swagger';
+import {
+	ApiCreatedResponse,
+	ApiNotFoundResponse,
+	ApiOperation,
+} from '@nestjs/swagger';
 
 export const CreateCommentSwagger = () => {
 	return applyDecorators(
@@ -8,6 +16,23 @@ export const CreateCommentSwagger = () => {
 		}),
 		ApiCreatedResponse({
 			description: '댓글 생성 성공',
+		}),
+		ApiNotFoundResponse({
+			description: ERROR_FEED_NOT_FOUND,
+		}),
+	);
+};
+
+export const UpdateCommentSwagger = () => {
+	return applyDecorators(
+		ApiOperation({
+			summary: '댓글 수정',
+		}),
+		ApiCreatedResponse({
+			description: '댓글 수정 성공',
+		}),
+		ApiNotFoundResponse({
+			description: `1. ${ERROR_FEED_NOT_FOUND} \n2. ${ERROR_COMMENT_NOT_FOUND}`,
 		}),
 	);
 };

--- a/backend/src/common/decorators/swagger/swagger-comment.decorator.ts
+++ b/backend/src/common/decorators/swagger/swagger-comment.decorator.ts
@@ -1,0 +1,13 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOperation } from '@nestjs/swagger';
+
+export const CreateCommentSwagger = () => {
+	return applyDecorators(
+		ApiOperation({
+			summary: '댓글 생성',
+		}),
+		ApiCreatedResponse({
+			description: '댓글 생성 성공',
+		}),
+	);
+};

--- a/backend/src/common/decorators/swagger/swagger-comment.decorator.ts
+++ b/backend/src/common/decorators/swagger/swagger-comment.decorator.ts
@@ -1,9 +1,11 @@
 import {
 	ERROR_COMMENT_NOT_FOUND,
+	ERROR_DELETE_COMMENT,
 	ERROR_FEED_NOT_FOUND,
 } from '@/constants/business-error';
 import { applyDecorators } from '@nestjs/common';
 import {
+	ApiConflictResponse,
 	ApiCreatedResponse,
 	ApiNotFoundResponse,
 	ApiOperation,
@@ -33,6 +35,23 @@ export const UpdateCommentSwagger = () => {
 		}),
 		ApiNotFoundResponse({
 			description: `1. ${ERROR_FEED_NOT_FOUND} \n2. ${ERROR_COMMENT_NOT_FOUND}`,
+		}),
+	);
+};
+
+export const DeleteCommentSwagger = () => {
+	return applyDecorators(
+		ApiOperation({
+			summary: '댓글 삭제',
+		}),
+		ApiCreatedResponse({
+			description: '댓글 삭제 성공',
+		}),
+		ApiNotFoundResponse({
+			description: `1. ${ERROR_FEED_NOT_FOUND} \n2. ${ERROR_COMMENT_NOT_FOUND}`,
+		}),
+		ApiConflictResponse({
+			description: ERROR_DELETE_COMMENT,
 		}),
 	);
 };

--- a/backend/src/constants/business-error.ts
+++ b/backend/src/constants/business-error.ts
@@ -47,3 +47,6 @@ export const ERROR_FILE_DIR_NOT_FOUND = '파일 경로를 찾을 수 없습니�
 export const ERROR_FEED_NOT_FOUND = '피드를 찾을 수 없습니다' as const;
 
 export const ERROR_COMMENT_NOT_FOUND = '댓글을 찾을 수 없습니다' as const;
+
+export const ERROR_DELETE_COMMENT =
+	'댓글을 삭제하는 도중 에러가 발생했습니다' as const;

--- a/backend/src/constants/business-error.ts
+++ b/backend/src/constants/business-error.ts
@@ -45,3 +45,5 @@ export const ERROR_DELETE_FEED_OR_MEDIA =
 export const ERROR_FILE_DIR_NOT_FOUND = '파일 경로를 찾을 수 없습니다' as const;
 
 export const ERROR_FEED_NOT_FOUND = '피드를 찾을 수 없습니다' as const;
+
+export const ERROR_COMMENT_NOT_FOUND = '댓글을 찾을 수 없습니다' as const;

--- a/backend/src/models/dto/comments/req/comment-create-req.dto.ts
+++ b/backend/src/models/dto/comments/req/comment-create-req.dto.ts
@@ -1,0 +1,9 @@
+import { CommentEntity } from '@/models/entities/comment.entity';
+import { PickType } from '@nestjs/swagger';
+
+export class CommentCreateReqDto extends PickType(CommentEntity, [
+	'commentContents',
+	'replyId',
+	'parentId',
+	'feedId',
+] as const) {}

--- a/backend/src/models/dto/comments/req/comment-create-req.dto.ts
+++ b/backend/src/models/dto/comments/req/comment-create-req.dto.ts
@@ -5,5 +5,4 @@ export class CommentCreateReqDto extends PickType(CommentEntity, [
 	'commentContents',
 	'replyId',
 	'parentId',
-	'feedId',
 ] as const) {}

--- a/backend/src/models/dto/comments/req/comment-update-req.dto.ts
+++ b/backend/src/models/dto/comments/req/comment-update-req.dto.ts
@@ -1,0 +1,6 @@
+import { CommentEntity } from '@/models/entities/comment.entity';
+import { PickType } from '@nestjs/swagger';
+
+export class CommentUpdateReqDto extends PickType(CommentEntity, [
+	'commentContents',
+] as const) {}

--- a/backend/src/models/dto/comments/res/comment-get-lists-res.dto.ts
+++ b/backend/src/models/dto/comments/res/comment-get-lists-res.dto.ts
@@ -1,0 +1,43 @@
+import { CommentEntity } from '@/models/entities/comment.entity';
+import {
+	ApiProperty,
+	ApiPropertyOptional,
+	OmitType,
+	PickType,
+} from '@nestjs/swagger';
+import { MemberResDto } from '../../member/res/member-res.dto';
+
+export class CommentGetListsResDto extends PickType(CommentEntity, [
+	'id',
+	'commentContents',
+	'updatedAt',
+	'replyId',
+	'parentId',
+	'feedId',
+] as const) {
+	@ApiProperty({
+		nullable: true,
+	})
+	myLikeByComment?: boolean;
+
+	@ApiProperty({
+		nullable: true,
+	})
+	sumLikeByComment?: number;
+
+	@ApiProperty({
+		nullable: false,
+	})
+	member!: MemberResDto;
+
+	@ApiPropertyOptional({
+		nullable: true,
+		type: () => [ChildrenCommentsResDtoSwagger],
+	})
+	childrenComments?: CommentGetListsResDto[];
+}
+
+export class ChildrenCommentsResDtoSwagger extends OmitType(
+	CommentGetListsResDto,
+	['childrenComments'] as const,
+) {}

--- a/backend/src/models/dto/feed/res/feed-res.dto.ts
+++ b/backend/src/models/dto/feed/res/feed-res.dto.ts
@@ -1,5 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { MediaResDto } from '../../media/res/media-res.dto';
+import { CommentGetListsResDto } from '../../comments/res/comment-get-lists-res.dto';
 
 export class FeedResDto {
 	@ApiProperty({
@@ -47,9 +48,15 @@ export class FeedResDto {
 	})
 	sumLike?: number;
 
-	@ApiProperty({
+	@ApiPropertyOptional({
 		nullable: true,
 		type: [MediaResDto],
 	})
 	medias?: MediaResDto[];
+
+	@ApiPropertyOptional({
+		nullable: true,
+		type: [CommentGetListsResDto],
+	})
+	comments?: CommentGetListsResDto[];
 }

--- a/backend/src/models/dto/member/res/member-res.dto.ts
+++ b/backend/src/models/dto/member/res/member-res.dto.ts
@@ -5,3 +5,5 @@ export class MemberResDto extends PickType(MemberEntity, [
 	'username',
 	'id',
 ] as const) {}
+
+//userProfileUrl

--- a/backend/src/models/entities/comment.entity.ts
+++ b/backend/src/models/entities/comment.entity.ts
@@ -1,0 +1,43 @@
+import { Column, Entity } from 'typeorm';
+import { DefaultEntity } from './common/default.entity';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+@Entity({ name: 'fam_comment' })
+export class CommentEntity extends DefaultEntity {
+	@Column({ type: 'text', nullable: false })
+	@ApiProperty({
+		nullable: false,
+	})
+	@IsNotEmpty()
+	@IsString()
+	commentContents!: string;
+
+	@ApiPropertyOptional({
+		nullable: true,
+	})
+	@IsOptional()
+	@IsUUID()
+	@Column('uuid', { nullable: true })
+	replyId?: string; // 실제 답글 단 댓글의 uuid
+
+	@ApiPropertyOptional({
+		nullable: true,
+	})
+	@IsOptional()
+	@IsUUID()
+	@Column('uuid', { nullable: true })
+	public readonly parentId?: string; //최초 부모격인 댓글 uuid
+
+	@Column({ type: 'uuid', nullable: false })
+	@ApiProperty()
+	@IsNotEmpty()
+	@IsUUID()
+	public readonly feedId!: string;
+
+	@Column({ type: 'uuid', nullable: false })
+	@ApiProperty()
+	@IsNotEmpty()
+	@IsUUID()
+	public readonly memberId!: string;
+}

--- a/backend/src/models/entities/comment.entity.ts
+++ b/backend/src/models/entities/comment.entity.ts
@@ -1,7 +1,10 @@
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { DefaultEntity } from './common/default.entity';
 import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { MemberEntity } from './member.entity';
+import { FeedEntity } from './feed.entity';
+import { LikeCommentEntity } from './fam-like-comment.entity';
 
 @Entity({ name: 'fam_comment' })
 export class CommentEntity extends DefaultEntity {
@@ -40,4 +43,23 @@ export class CommentEntity extends DefaultEntity {
 	@IsNotEmpty()
 	@IsUUID()
 	public readonly memberId!: string;
+
+	@ManyToOne(() => CommentEntity, (comment) => comment.childrenComments)
+	@JoinColumn({ name: 'parentId', referencedColumnName: 'id' })
+	parent?: CommentEntity;
+
+	@ManyToOne((type) => MemberEntity, (mb) => mb.memberCreateComments)
+	@JoinColumn({ name: 'memberId', referencedColumnName: 'id' })
+	member!: MemberEntity;
+
+	@ManyToOne((type) => FeedEntity, (fd) => fd.comments)
+	@JoinColumn({ name: 'feedId', referencedColumnName: 'id' })
+	feed!: FeedEntity;
+
+	@OneToMany(() => CommentEntity, (comment) => comment.parent)
+	childrenComments?: CommentEntity[];
+
+	// comment-like
+	@OneToMany(() => LikeCommentEntity, (lcm) => lcm.comment)
+	LikedByComments?: LikeCommentEntity[];
 }

--- a/backend/src/models/entities/fam-like-comment.entity.ts
+++ b/backend/src/models/entities/fam-like-comment.entity.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsUUID } from 'class-validator';
+import { CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'fam_like_comment' })
+export class LikeCommentEntity {
+	@PrimaryColumn('uuid')
+	@ApiProperty({
+		nullable: false,
+	})
+	@IsNotEmpty()
+	@IsUUID()
+	public readonly memberId!: string;
+
+	@PrimaryColumn('uuid')
+	@ApiProperty({
+		nullable: false,
+	})
+	@IsNotEmpty()
+	@IsUUID()
+	public readonly commentId!: string;
+
+	@ApiProperty()
+	@CreateDateColumn({
+		type: 'timestamp',
+		precision: 3,
+		default: () => 'CURRENT_TIMESTAMP',
+	})
+	createdAt!: Date;
+}

--- a/backend/src/models/entities/fam-like-comment.entity.ts
+++ b/backend/src/models/entities/fam-like-comment.entity.ts
@@ -1,6 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsUUID } from 'class-validator';
-import { CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
+import {
+	CreateDateColumn,
+	Entity,
+	JoinColumn,
+	ManyToOne,
+	PrimaryColumn,
+} from 'typeorm';
+import { MemberEntity } from './member.entity';
+import { CommentEntity } from './comment.entity';
 
 @Entity({ name: 'fam_like_comment' })
 export class LikeCommentEntity {
@@ -19,6 +27,14 @@ export class LikeCommentEntity {
 	@IsNotEmpty()
 	@IsUUID()
 	public readonly commentId!: string;
+
+	@ManyToOne((type) => MemberEntity, (member) => member.memberLikesComments)
+	@JoinColumn({ name: 'memberId', referencedColumnName: 'id' })
+	member!: MemberEntity;
+
+	@ManyToOne((type) => CommentEntity, (cm) => cm.LikedByComments)
+	@JoinColumn({ name: 'commentId', referencedColumnName: 'id' })
+	comment!: CommentEntity;
 
 	@ApiProperty()
 	@CreateDateColumn({

--- a/backend/src/models/entities/feed.entity.ts
+++ b/backend/src/models/entities/feed.entity.ts
@@ -6,6 +6,7 @@ import { LikeFeedEntity } from './fam-like-feed.entity';
 import { FeedMediaEntity } from './fam-feed-media.entity';
 import { GroupEntity } from './group.entity';
 import { MemberEntity } from './member.entity';
+import { CommentEntity } from './comment.entity';
 
 @Entity({ name: 'fam_feed' })
 export class FeedEntity extends DefaultEntity {
@@ -48,4 +49,8 @@ export class FeedEntity extends DefaultEntity {
 	@ManyToOne((type) => MemberEntity, (mb) => mb.memberCreateFeeds)
 	@JoinColumn({ name: 'memberId', referencedColumnName: 'id' })
 	member!: MemberEntity;
+
+	// comment
+	@OneToMany(() => CommentEntity, (cm) => cm.feed)
+	comments?: CommentEntity[];
 }

--- a/backend/src/models/entities/member.entity.ts
+++ b/backend/src/models/entities/member.entity.ts
@@ -13,6 +13,8 @@ import {
 import { FamEntity } from './fam.entity';
 import { LikeFeedEntity } from './fam-like-feed.entity';
 import { FeedEntity } from './feed.entity';
+import { CommentEntity } from './comment.entity';
+import { LikeCommentEntity } from './fam-like-comment.entity';
 
 @Entity({ name: 'fam_member' })
 @Unique(['email'])
@@ -77,4 +79,12 @@ export class MemberEntity extends DefaultEntity {
 
 	@OneToMany(() => FeedEntity, (fe) => fe.member)
 	memberCreateFeeds?: FeedEntity[];
+
+	// comment
+	@OneToMany(() => CommentEntity, (cm) => cm.member)
+	memberCreateComments?: CommentEntity[];
+
+	// comment-like
+	@OneToMany(() => LikeCommentEntity, (lkc) => lkc.member)
+	memberLikesComments?: LikeCommentEntity[];
 }

--- a/backend/src/models/repositories/comments.repository.ts
+++ b/backend/src/models/repositories/comments.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { CommentEntity } from '../entities/comment.entity';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import { ICreateCommentsArgs } from '@/types/args/comment';
@@ -12,6 +12,39 @@ export class CommentsRepository extends Repository<CommentEntity> {
 		private readonly repository: Repository<CommentEntity>,
 	) {
 		super(repository.target, repository.manager, repository.queryRunner);
+	}
+
+	async getCommentsByFeedId(feedId: string) {
+		return await this.repository.find({
+			select: {
+				id: true,
+				commentContents: true,
+				replyId: true,
+				parentId: true,
+				feedId: true,
+				updatedAt: true,
+				childrenComments: true,
+				member: {
+					id: true,
+					username: true,
+				},
+			},
+			where: {
+				parentId: IsNull(),
+				feedId: feedId,
+			},
+			relations: {
+				childrenComments: true,
+				member: true,
+				LikedByComments: true,
+			},
+			order: {
+				updatedAt: 'ASC',
+				childrenComments: {
+					updatedAt: 'ASC',
+				},
+			},
+		});
 	}
 
 	async createComment({

--- a/backend/src/models/repositories/comments.repository.ts
+++ b/backend/src/models/repositories/comments.repository.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { CommentEntity } from '../entities/comment.entity';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { ICreateCommentsArgs } from '@/types/args/comment';
 
 @Injectable()
 export class CommentsRepository extends Repository<CommentEntity> {
@@ -10,5 +12,22 @@ export class CommentsRepository extends Repository<CommentEntity> {
 		private readonly repository: Repository<CommentEntity>,
 	) {
 		super(repository.target, repository.manager, repository.queryRunner);
+	}
+
+	async createComments({
+		commentContents,
+		replyId,
+		parentId,
+		feedId,
+		memberId,
+	}: ICreateCommentsArgs) {
+		await this.repository.insert({
+			id: uuidv4(),
+			commentContents: commentContents,
+			replyId: replyId,
+			parentId: parentId,
+			feedId: feedId,
+			memberId: memberId,
+		});
 	}
 }

--- a/backend/src/models/repositories/comments.repository.ts
+++ b/backend/src/models/repositories/comments.repository.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { CommentEntity } from '../entities/comment.entity';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class CommentsRepository extends Repository<CommentEntity> {
+	constructor(
+		@InjectRepository(CommentEntity)
+		private readonly repository: Repository<CommentEntity>,
+	) {
+		super(repository.target, repository.manager, repository.queryRunner);
+	}
+}

--- a/backend/src/models/repositories/comments.repository.ts
+++ b/backend/src/models/repositories/comments.repository.ts
@@ -34,4 +34,12 @@ export class CommentsRepository extends Repository<CommentEntity> {
 	async updateComment(commentId: string, commentContents: string) {
 		await this.update({ id: commentId }, { commentContents: commentContents });
 	}
+
+	async deleteComment(commentId: string) {
+		const { affected } = await this.delete({
+			id: commentId,
+		});
+
+		return !!affected;
+	}
 }

--- a/backend/src/models/repositories/comments.repository.ts
+++ b/backend/src/models/repositories/comments.repository.ts
@@ -14,7 +14,7 @@ export class CommentsRepository extends Repository<CommentEntity> {
 		super(repository.target, repository.manager, repository.queryRunner);
 	}
 
-	async createComments({
+	async createComment({
 		commentContents,
 		replyId,
 		parentId,
@@ -29,5 +29,9 @@ export class CommentsRepository extends Repository<CommentEntity> {
 			feedId: feedId,
 			memberId: memberId,
 		});
+	}
+
+	async updateComment(commentId: string, commentContents: string) {
+		await this.update({ id: commentId }, { commentContents: commentContents });
 	}
 }

--- a/backend/src/models/repositories/likes-comment.repository.ts
+++ b/backend/src/models/repositories/likes-comment.repository.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { LikeCommentEntity } from '../entities/fam-like-comment.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class LikesCommentRepository extends Repository<LikeCommentEntity> {
+	constructor(
+		@InjectRepository(LikeCommentEntity)
+		private readonly repository: Repository<LikeCommentEntity>,
+	) {
+		super(repository.target, repository.manager, repository.queryRunner);
+	}
+}

--- a/backend/src/types/args/comment.ts
+++ b/backend/src/types/args/comment.ts
@@ -1,0 +1,5 @@
+import { CommentCreateReqDto } from '@/models/dto/comments/req/comment-create-req.dto';
+
+export interface ICreateCommentsArgs extends CommentCreateReqDto {
+	memberId: string;
+}

--- a/backend/src/types/args/comment.ts
+++ b/backend/src/types/args/comment.ts
@@ -1,5 +1,6 @@
 import { CommentCreateReqDto } from '@/models/dto/comments/req/comment-create-req.dto';
 
 export interface ICreateCommentsArgs extends CommentCreateReqDto {
+	feedId: string;
 	memberId: string;
 }


### PR DESCRIPTION
* Closes #44 

## ✨ **구현 기능 명세**
- 댓글 entity생성
- 댓글 좋아요 entity생성
- 댓글 entity관련 관계 설정
-  대댓글 관련 관계 설정
- 댓글 생성 api 기능 추가
- 댓글 수정 api 기능 추가
- 댓글 삭제 api 기능 추가
- feedId에 해당하는 댓글 전체 가져오기

## 🎁 **주목할 점**

## 😭 **어려웠던 점**
```typescript
export class CommentGetListsResDto extends PickType(CommentEntity, [
	'id',
	'commentContents',
	'updatedAt',
	'replyId',
	'parentId',
	'feedId',
] as const) {
	@ApiProperty({
		nullable: true,
	})
	myLikeByComment?: boolean;

	@ApiProperty({
		nullable: true,
	})
	sumLikeByComment?: number;

	@ApiProperty({
		nullable: false,
	})
	member!: MemberResDto;

	@ApiPropertyOptional({
		nullable: true,
		type: () => [ChildrenCommentsResDtoSwagger],
	})
	childrenComments?: CommentGetListsResDto[];
}

export class ChildrenCommentsResDtoSwagger extends OmitType(
	CommentGetListsResDto,
	['childrenComments'] as const,
) {}
```

- 이상하게도 ApiPropertyOptional에서 type 프로퍼티에서 자식 comment가 다시 재귀로 호출 해야 되는데 type:CommentGetListsResDto 하게 되면 swagger 문서에서 안보인다.
- 그래서 상속 받는 클래스 ChildrenCommentsResDtoSwagger를 만들어줘서 swagger type프로퍼티에 넣어 주었다.

## 🌄 **스크린샷**
- type 프로퍼티에 재귀호출
<img width="793" alt="image" src="https://github.com/YangGwangSeong/family-social/assets/52439610/d5d7ceaa-de30-4628-851a-988d97481376">

- ChildrenCommentsResDtoSwagger 따로 만들어서 type 프로퍼티에 넣어줌
<img width="949" alt="image" src="https://github.com/YangGwangSeong/family-social/assets/52439610/132ddf0e-71d8-4a8e-bf86-c134ec45ef12">

