### PR TITLE
Feature/208-group-detail-contents

### DIFF
--- a/backend/src/api/feeds/feeds.module.ts
+++ b/backend/src/api/feeds/feeds.module.ts
@@ -28,7 +28,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
 	],
 	controllers: [FeedsController],
 	providers: [FeedsService, FeedsRepository, LikesFeedRepository],
-	exports: [],
+	exports: [FeedsService],
 })
 export class FeedsModule implements NestModule {
 	configure(consumer: MiddlewareConsumer) {

--- a/backend/src/api/feeds/feeds.service.ts
+++ b/backend/src/api/feeds/feeds.service.ts
@@ -61,7 +61,14 @@ export class FeedsService {
 	async findAllFeed(
 		page: number,
 		memberId: string,
-		options: 'TOP' | 'MYFEED' | 'ALL',
+		options:
+			| 'TOP'
+			| 'MYFEED'
+			| 'ALL'
+			| 'GROUPFEED'
+			| 'GROUPMEMBER'
+			| 'GROUPEVENT',
+		groupId?: string,
 	): Promise<FeedGetAllResDto> {
 		const { take, skip } = getOffset({ page });
 		const { list, count } = await this.feedsRepository.findAllFeed({
@@ -69,6 +76,7 @@ export class FeedsService {
 			skip,
 			memberId,
 			options,
+			groupId,
 		});
 
 		const mappedList = await Promise.all(

--- a/backend/src/api/groups/groups.controller.ts
+++ b/backend/src/api/groups/groups.controller.ts
@@ -22,6 +22,7 @@ import {
 	CreateGroupSwagger,
 	DeleteFamByMemberOfGroupSwagger,
 	DeleteGroupSwagger,
+	GetFeedsOfGroupSwagger,
 	GetMemberBelongToGroupsSwagger,
 	GetMemberListBelongToGroupSwagger,
 	PostInvitedEmailsOfGroupSwagger,
@@ -58,6 +59,7 @@ import { TourismPeriodUpdateReqDto } from '@/models/dto/schedule/req/tourism-per
 
 import { GroupsService } from './groups.service';
 import { FamsService } from '../fams/fams.service';
+import { FeedsService } from '../feeds/feeds.service';
 import { MailsService } from '../mails/mails.service';
 import { MembersService } from '../members/members.service';
 import { SchedulesService } from '../schedules/schedules.service';
@@ -73,6 +75,7 @@ export class GroupsController {
 		private readonly membersService: MembersService,
 		private readonly schedulesService: SchedulesService,
 		private readonly mailsService: MailsService,
+		private readonly feedsService: FeedsService,
 	) {}
 
 	/**
@@ -216,6 +219,37 @@ export class GroupsController {
 			page,
 			limit,
 		});
+	}
+
+	/**
+	 * @summary 특정 그룹에 해당하는 피드를 가져옵니다.
+	 *
+	 * @tag groups
+	 * @param page 페이징을 위한 page 번호
+	 * @param options 조회 옵션
+	 * @param sub 인증된 사용자의 아이디
+	 * @param groupId 특정 그룹 아이디
+	 * @author YangGwangSeong <soaw83@gmail.com>
+	 * @returns feed
+	 */
+	@GetFeedsOfGroupSwagger()
+	@Get('/:groupId/feeds')
+	async getFeedsOfGroup(
+		@Param(
+			'groupId',
+			new ParseUUIDPipe({ exceptionFactory: parseUUIDPipeMessage }),
+		)
+		groupId: string,
+		@Query('options') options: 'GROUPFEED' | 'GROUPMEMBER' | 'GROUPEVENT',
+		@Query(
+			'page',
+			new DefaultValuePipe(1),
+			new ParseIntPipe({ exceptionFactory: () => parseIntPipeMessage('page') }),
+		)
+		page: number,
+		@CurrentUser('sub') sub: string,
+	) {
+		return await this.feedsService.findAllFeed(page, sub, options, groupId);
 	}
 
 	/**

--- a/backend/src/api/groups/groups.module.ts
+++ b/backend/src/api/groups/groups.module.ts
@@ -16,6 +16,7 @@ import { GroupsRepository } from '@/models/repositories/groups.repository';
 import { GroupsController } from './groups.controller';
 import { GroupsService } from './groups.service';
 import { FamsModule } from '../fams/fams.module';
+import { FeedsModule } from '../feeds/feeds.module';
 import { MailsModule } from '../mails/mails.module';
 import { MembersModule } from '../members/members.module';
 import { SchedulesModule } from '../schedules/schedules.module';
@@ -27,6 +28,7 @@ import { SchedulesModule } from '../schedules/schedules.module';
 		MembersModule,
 		SchedulesModule,
 		MailsModule,
+		FeedsModule,
 	],
 	controllers: [GroupsController],
 	providers: [GroupsService, GroupsRepository, FamsRepository],

--- a/backend/src/common/decorators/swagger/swagger-group.decorator.ts
+++ b/backend/src/common/decorators/swagger/swagger-group.decorator.ts
@@ -23,6 +23,7 @@ import {
 	ERROR_USER_NOT_FOUND,
 } from '@/constants/business-error';
 import { FamResDto } from '@/models/dto/fam/res/fam-res.dto';
+import { FeedGetAllResDto } from '@/models/dto/feed/res/feed-get-all-res.dto';
 import { BelongToGroupResDto } from '@/models/dto/group/res/belong-to-group.res.dto';
 import { GroupMembersResDto } from '@/models/dto/group/res/group-members.res.dto';
 import { GroupResDto } from '@/models/dto/group/res/group-res.dto';
@@ -39,6 +40,18 @@ export const GetMemberListBelongToGroupSwagger = () => {
 		}),
 		ApiForbiddenResponse({
 			description: `${ERROR_NO_PERMISSTION_TO_GROUP}`,
+		}),
+	);
+};
+
+export const GetFeedsOfGroupSwagger = () => {
+	return applyDecorators(
+		ApiOperation({
+			summary: '특정 그룹에 해당하는 피드를 가져옵니다',
+		}),
+		ApiCreatedResponse({
+			description: '특정 그룹에 해당하는 피드를 가져오기 성공',
+			type: FeedGetAllResDto,
 		}),
 	);
 };

--- a/backend/src/models/repositories/feeds.repository.ts
+++ b/backend/src/models/repositories/feeds.repository.ts
@@ -75,11 +75,19 @@ export class FeedsRepository extends Repository<FeedEntity> {
 		skip,
 		memberId,
 		options,
+		groupId,
 	}: {
 		take: number;
 		skip: number;
 		memberId: string;
-		options: 'TOP' | 'MYFEED' | 'ALL';
+		options:
+			| 'TOP'
+			| 'MYFEED'
+			| 'ALL'
+			| 'GROUPFEED'
+			| 'GROUPMEMBER'
+			| 'GROUPEVENT';
+		groupId?: string;
 	}): Promise<{ list: Omit<FeedResDto, 'medias'>[]; count: number }> {
 		const query = this.repository
 			.createQueryBuilder('a')
@@ -117,6 +125,12 @@ export class FeedsRepository extends Repository<FeedEntity> {
 		} else {
 			query.where('a.isPublic = :isPublic', { isPublic: true });
 		}
+
+		if (options === 'GROUPFEED') {
+			query.andWhere('a.groupId = :groupId', { groupId });
+		}
+
+		console.log(query);
 
 		const [list, count] = await Promise.all([
 			query.getRawMany(),

--- a/frontend/components/screens/feed/Feed.module.scss
+++ b/frontend/components/screens/feed/Feed.module.scss
@@ -27,7 +27,7 @@
 					@screen md {
 						@apply mx-0;
 					}
-					@apply mx-2 z-10;
+					@apply mx-4 z-10;
 				}
 
 				.feed_container {

--- a/frontend/components/screens/group/detail/GroupDetail.module.scss
+++ b/frontend/components/screens/group/detail/GroupDetail.module.scss
@@ -70,9 +70,17 @@
 						@screen md {
 							@apply mx-0;
 						}
-						@apply mx-2 z-10 mt-8 mb-6;
+						@apply mx-4 z-10 mt-8 mb-6;
 					}
 				}
+			}
+
+			// mobile-create-feed-btn
+			.mobile_create_feed_btn_container {
+				@screen md {
+					@apply hidden;
+				}
+				@apply fixed bottom-6 right-4 border border-solid border-customDark bg-customOrange flex justify-center items-center rounded-full p-4 z-30;
 			}
 		}
 	}

--- a/frontend/components/screens/group/detail/GroupDetail.module.scss
+++ b/frontend/components/screens/group/detail/GroupDetail.module.scss
@@ -54,6 +54,13 @@
 							}
 						}
 					}
+
+					.tap_menu_container {
+						@screen md {
+							@apply mx-0;
+						}
+						@apply mx-2 z-10 mt-8 mb-6;
+					}
 				}
 			}
 		}

--- a/frontend/components/screens/group/detail/GroupDetail.module.scss
+++ b/frontend/components/screens/group/detail/GroupDetail.module.scss
@@ -6,13 +6,15 @@
 
 	//컨텐츠
 	.contents_container {
-		@apply flex;
+		@apply flex relative overflow-x-hidden;
 		height: calc(100vh - 80px);
 		overflow-y: auto; /* 스크롤 가능한 컨테이너로 만듭니다. 이걸 해주어야 왼쪽 사이드바 sticky가 먹음 */
 
 		.detail_container {
-			@apply relative;
-			flex: 1;
+			@screen md {
+				flex: 1;
+			}
+			@apply relative w-full z-10;
 
 			.main {
 				@apply h-full;
@@ -71,6 +73,11 @@
 							@apply mx-0;
 						}
 						@apply mx-4 z-10 mt-8 mb-6;
+					}
+
+					// feed container
+					.feed_container {
+						@apply pt-6 pb-8 flex flex-col gap-10 z-10;
 					}
 				}
 			}

--- a/frontend/components/screens/group/detail/GroupDetail.module.scss
+++ b/frontend/components/screens/group/detail/GroupDetail.module.scss
@@ -45,12 +45,23 @@
 
 						.banner_profile_right_contaienr {
 							@screen md {
-								@apply ml-auto;
+								@apply ml-auto flex gap-4;
 							}
-							@apply ml-0;
+							@apply ml-0 block;
+
+							.create_feed_btn {
+								@screen md {
+									@apply block w-[200px];
+								}
+								@apply hidden;
+							}
 
 							.toggle_menu_container {
-								@apply flex justify-center items-center relative;
+								@screen md {
+									@apply w-[200px];
+								}
+
+								@apply flex justify-center items-center relative w-full;
 							}
 						}
 					}

--- a/frontend/components/screens/group/detail/GroupDetail.tsx
+++ b/frontend/components/screens/group/detail/GroupDetail.tsx
@@ -164,6 +164,7 @@ const GroupDetail: FC = () => {
 												rounded-full w-full py-[10px] px-7
 												hover:bg-orange-500
 												"
+												onClick={handleCreateFeed}
 											>
 												+ 피드
 											</CustomButton>

--- a/frontend/components/screens/group/detail/GroupDetail.tsx
+++ b/frontend/components/screens/group/detail/GroupDetail.tsx
@@ -12,6 +12,8 @@ import { InviteMenu } from '@/components/ui/modal/toggle-menu.constants';
 import { useModal } from '@/hooks/useModal';
 import { PiPencilDuotone } from 'react-icons/pi';
 import { motion } from 'framer-motion';
+import TabMenu from '@/components/ui/tab-menu/TabMenu';
+import { groupTabMenus } from '@/components/ui/tab-menu/tab-menu.constants';
 
 const GroupDetail: FC = () => {
 	const router = useRouter();
@@ -74,6 +76,11 @@ const GroupDetail: FC = () => {
 										</motion.div>
 									</div>
 								</div>
+								{/* 탭 메뉴 */}
+								<div className={styles.tap_menu_container}>
+									<TabMenu list={groupTabMenus} options={'GROUPFEED'} />
+								</div>
+								<div>피드</div>
 							</div>
 						</div>
 					</div>

--- a/frontend/components/screens/group/detail/GroupDetail.tsx
+++ b/frontend/components/screens/group/detail/GroupDetail.tsx
@@ -50,6 +50,18 @@ const GroupDetail: FC = () => {
 									{/* 프로필 */}
 									<Profile username="양광성" role="관리자" />
 									<div className={styles.banner_profile_right_contaienr}>
+										<div className={styles.create_feed_btn}>
+											<CustomButton
+												type="button"
+												className="bg-customOrange text-customDark 
+												font-bold border border-solid border-customDark 
+												rounded-full w-full py-[10px] px-7
+												hover:bg-orange-500
+												"
+											>
+												+ 피드
+											</CustomButton>
+										</div>
 										<motion.div
 											className={styles.toggle_menu_container}
 											initial={false}

--- a/frontend/components/screens/group/detail/GroupDetail.tsx
+++ b/frontend/components/screens/group/detail/GroupDetail.tsx
@@ -14,10 +14,14 @@ import { PiPencilDuotone } from 'react-icons/pi';
 import { motion } from 'framer-motion';
 import TabMenu from '@/components/ui/tab-menu/TabMenu';
 import { groupTabMenus } from '@/components/ui/tab-menu/tab-menu.constants';
+import { BUTTONGESTURE } from '@/utils/animation/gestures';
+import { useCreateFeed } from '@/hooks/useCreateFeed';
 
 const GroupDetail: FC = () => {
 	const router = useRouter();
 	const { groupId } = router.query as { groupId: string };
+
+	const { handleCreateFeed } = useCreateFeed();
 
 	const invitationModalWrapperRef = useRef<HTMLDivElement>(null);
 	const {
@@ -94,6 +98,14 @@ const GroupDetail: FC = () => {
 								</div>
 								<div>피드</div>
 							</div>
+						</div>
+						<div
+							className={styles.mobile_create_feed_btn_container}
+							onClick={handleCreateFeed}
+						>
+							<motion.div {...BUTTONGESTURE}>
+								<PiPencilDuotone size={28} color="#0a0a0a" />
+							</motion.div>
 						</div>
 					</div>
 				</div>

--- a/frontend/components/screens/group/detail/GroupDetail.tsx
+++ b/frontend/components/screens/group/detail/GroupDetail.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, useState } from 'react';
+import React, { FC, useEffect, useRef, useState } from 'react';
 import styles from './GroupDetail.module.scss';
 import Format from '@/components/ui/layout/Format';
 import { useRouter } from 'next/router';
@@ -11,17 +11,35 @@ import ToggleModal from '@/components/ui/modal/ToggleModal';
 import { InviteMenu } from '@/components/ui/modal/toggle-menu.constants';
 import { useModal } from '@/hooks/useModal';
 import { PiPencilDuotone } from 'react-icons/pi';
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import TabMenu from '@/components/ui/tab-menu/TabMenu';
 import { groupTabMenus } from '@/components/ui/tab-menu/tab-menu.constants';
 import { BUTTONGESTURE } from '@/utils/animation/gestures';
 import { useCreateFeed } from '@/hooks/useCreateFeed';
+import LottieLike from '@/components/ui/lottie/LottieLike';
+import { useLottieLike } from '@/hooks/useLottieLike';
+import { useFeedLike } from '@/hooks/useFeedLike';
+import { useCommentLike } from '@/hooks/useCommentLike';
+import { useInfiniteQuery } from 'react-query';
+import { FeedService } from '@/services/feed/feed.service';
+import { GroupService } from '@/services/group/group.service';
+import Skeleton from '@/components/ui/skeleton/Skeleton';
+import FeedItem from '@/components/ui/feed/FeedItem';
 
 const GroupDetail: FC = () => {
 	const router = useRouter();
+
+	const query = router.query as {
+		options: 'GROUPFEED' | 'GROUPMEMBER' | 'GROUPEVENT';
+	};
+
+	const [observedPost, setObservedPost] = useState('');
+
 	const { groupId } = router.query as { groupId: string };
 
 	const { handleCreateFeed } = useCreateFeed();
+
+	const { handleIsLottie, lottieRef, handleLottieComplete } = useLottieLike();
 
 	const invitationModalWrapperRef = useRef<HTMLDivElement>(null);
 	const {
@@ -29,12 +47,96 @@ const GroupDetail: FC = () => {
 		handleToggleModal: handleCloseInvitationModal,
 	} = useModal(invitationModalWrapperRef);
 
+	const {
+		data,
+		fetchNextPage,
+		hasNextPage,
+		isLoading,
+		isError,
+		isRefetching,
+		refetch,
+	} = useInfiniteQuery(
+		['feeds'],
+		async ({ pageParam = 1 }) =>
+			await GroupService.getFeedsOfGroup(
+				pageParam,
+				query.options ?? 'GROUPFEED',
+				groupId,
+			),
+		{
+			getNextPageParam: (lastPage, allPosts) => {
+				return lastPage.page !== allPosts[0].totalPage
+					? lastPage.page + 1
+					: undefined;
+			},
+			enabled: !!groupId,
+		},
+	);
+
+	const handleRefetch = (pageValue: number) => {
+		refetch({ refetchPage: (page, index) => index === pageValue - 1 });
+	};
+
+	const { handleUpdateLike } = useFeedLike({ handleRefetch, handleIsLottie });
+
+	const { handleLikeComment } = useCommentLike({
+		handleRefetch,
+		handleIsLottie,
+	});
+
+	useEffect(() => {
+		const observeElement = (element: HTMLElement | null) => {
+			if (!element) return;
+			// 브라우저 viewport와 설정한 요소(Element)와 교차점을 관찰
+			const observer = new IntersectionObserver(
+				// entries는 IntersectionObserverEntry 인스턴스의 배열
+				entries => {
+					console.log('entries', entries);
+					// isIntersecting: 관찰 대상의 교차 상태(Boolean)
+					if (entries[0].isIntersecting === true) {
+						console.log('마지막 포스트에 왔습니다');
+						fetchNextPage();
+						observer.unobserve(element); //이전에 observe 하고 있던걸 없애준다.
+					}
+				},
+				{ threshold: 1 },
+			);
+			// 대상 요소의 관찰을 시작
+			observer.observe(element);
+		};
+
+		//포스트가 없다면 return
+		if (
+			!data?.pages[data?.pages.length - 1].list ||
+			data?.pages[data?.pages.length - 1].list.length === 0
+		)
+			return;
+		//posts 배열안에 마지막 post에 id를 가져옵니다.
+		const id =
+			data?.pages[data?.pages.length - 1].list[
+				data?.pages[data?.pages.length - 1].list.length - 1
+			].feedId;
+		//posts 배열에 post가 추가되서 마지막 post가 바뀌었다면
+		// 바뀐 post중 마지막post를 observedPost로
+		if (id !== observedPost) {
+			setObservedPost(id);
+			observeElement(document.getElementById(id));
+		}
+		return () => {};
+	}, [data, fetchNextPage, observedPost]);
+
 	return (
 		<Format title={'group-detail'}>
 			<div className={styles.container}>
 				{/* 헤더 */}
 				<Header />
 				<div className={styles.contents_container}>
+					{/* lottie-like */}
+					<LottieLike
+						lottieRef={lottieRef}
+						onLottieComplete={handleLottieComplete}
+					/>
+
 					<GroupDetailSidebar groupId={groupId} />
 					<div className={styles.detail_container}>
 						<div className={styles.main}>
@@ -96,7 +198,33 @@ const GroupDetail: FC = () => {
 								<div className={styles.tap_menu_container}>
 									<TabMenu list={groupTabMenus} options={'GROUPFEED'} />
 								</div>
-								<div>피드</div>
+								<div className={styles.feed_container}>
+									{isLoading && <Skeleton />}
+
+									{data?.pages.map((page, pageIndex) => (
+										<AnimatePresence key={pageIndex}>
+											{page.list.map((feed, index) => (
+												<FeedItem
+													key={feed.feedId}
+													feed={feed}
+													index={index}
+													onLike={handleUpdateLike}
+													page={page.page}
+													onRefetch={handleRefetch}
+													onLikeComment={handleLikeComment}
+												/>
+											))}
+										</AnimatePresence>
+									))}
+
+									{isRefetching && (
+										<React.Fragment>
+											<Skeleton />
+											<Skeleton />
+											<Skeleton />
+										</React.Fragment>
+									)}
+								</div>
 							</div>
 						</div>
 						<div

--- a/frontend/components/screens/notification/Notification.module.scss
+++ b/frontend/components/screens/notification/Notification.module.scss
@@ -24,7 +24,7 @@
 				@apply w-full h-full mt-8 z-10 flex flex-col gap-6;
 
 				.tap_menu_container {
-					@apply mx-2 z-10;
+					@apply mx-4 z-10;
 				}
 
 				.notification_lst_container {

--- a/frontend/components/ui/layout/sidebar/group/detail/GroupDetailSidebar.module.scss
+++ b/frontend/components/ui/layout/sidebar/group/detail/GroupDetailSidebar.module.scss
@@ -9,7 +9,7 @@
 		width: 300px;
 	}
 
-	@apply w-full pt-3 border-r border-solid border-customDark h-full fixed top-0 z-50 bg-basic;
+	@apply w-full pt-3 border-r border-solid border-customDark h-full fixed top-0 z-[70] bg-basic;
 
 	// mobile_close
 	.mobile_close_btn {

--- a/frontend/components/ui/layout/sidebar/main/MainSidebar.module.scss
+++ b/frontend/components/ui/layout/sidebar/main/MainSidebar.module.scss
@@ -1,15 +1,15 @@
 .sidebar_container {
 	@screen 2xl {
-		@apply sticky top-0;
+		@apply top-0 z-[50];
 		width: 300px;
 	}
 
 	@screen md {
-		@apply top-20;
+		@apply top-20 z-[50];
 		width: 300px;
 	}
 
-	@apply w-full px-11 pt-3 border-r border-solid border-customDark h-full top-0 z-50 fixed bg-basic block;
+	@apply w-full px-11 pt-3 border-r border-solid border-customDark h-full top-0 z-[70] fixed bg-basic block;
 
 	// mobile_close
 	.mobile_close_btn {

--- a/frontend/components/ui/tab-menu/tab-menu.constants.ts
+++ b/frontend/components/ui/tab-menu/tab-menu.constants.ts
@@ -84,3 +84,21 @@ export const notificationsTabMenus: TabeMenuListType[] = [
 		title: '안읽음',
 	},
 ];
+
+export const groupTabMenus: TabeMenuListType[] = [
+	{
+		link: '/groups/75aca3da-1dac-48ef-84b8-cdf1be8fe37d',
+		options: 'GROUPFEED',
+		title: '피드',
+	},
+	{
+		link: '/groups/75aca3da-1dac-48ef-84b8-cdf1be8fe37d',
+		options: 'GROUPMEMBER',
+		title: '멤버',
+	},
+	{
+		link: '/groups/75aca3da-1dac-48ef-84b8-cdf1be8fe37d',
+		options: 'GROUPEVENT',
+		title: '이벤트',
+	},
+];

--- a/frontend/services/group/group.service.ts
+++ b/frontend/services/group/group.service.ts
@@ -1,3 +1,4 @@
+import { FeedsResponse } from '@/shared/interfaces/feed.interface';
 import {
 	GroupResponse,
 	MemberBelongToGroupsResponse,
@@ -8,6 +9,18 @@ export const GroupService = {
 	async getMemberBelongToGroups(): Promise<MemberBelongToGroupsResponse[]> {
 		const { data } = await axiosAPI.get<MemberBelongToGroupsResponse[]>(
 			'/groups',
+		);
+
+		return data;
+	},
+
+	async getFeedsOfGroup(
+		page: number,
+		options: 'GROUPFEED' | 'GROUPMEMBER' | 'GROUPEVENT' = 'GROUPFEED',
+		groupId: string,
+	) {
+		const { data } = await axiosAPI.get<FeedsResponse>(
+			`/groups/${groupId}/feeds?page=${page}&options=${options}`,
 		);
 
 		return data;

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -33,6 +33,9 @@ export const TabMenus = [
 	'FESTIVAL',
 	'NOTREAD',
 	'READ',
+	'GROUPFEED',
+	'GROUPMEMBER',
+	'GROUPEVENT',
 ] as const;
 export const schdulePages = [
 	'selectGroupPage',


### PR DESCRIPTION
* Closes #208 

## ✨ **구현 기능 명세**
- 그룹 디테일 페이지 콘텐츠 영역에 특정 그룹에 해당하는 피드들 가져오기
- 그룹 디테일 페이지 콘텐츠 영역에 특정 그룹에 해당하는 여행일정들 가져오기
- 그룹 데테일 페이지에서 바로 생성하는것이기 때문에 그룹 선택은 자동
- 그룹 디테일 페이지 탭 메뉴 만들기 (피드, 멤버, 이벤트) 이벤트에는 가족 생일 등록 그런거 할 수 있게

## 🎁 **주목할 점**

## 😭 **어려웠던 점**

## 🌄 **스크린샷**
